### PR TITLE
correct beebotte install

### DIFF
--- a/installation.sh
+++ b/installation.sh
@@ -13,4 +13,5 @@ apt install -y default-jre
 #
 # Python3.5 will be used for emulated networks (modbus), Python3.9 will be used for IoT
 apt install -y python3-pip
+python3.9 -m pip install pymodbus==2.5.2 urllib3==1.26.6 setuptools termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
 python3 -m pip install pymodbus termcolor twisted

--- a/installation.sh
+++ b/installation.sh
@@ -14,5 +14,5 @@ apt install -y default-jre
 # Python3.5 will be used for emulated networks (modbus), Python3.9 will be used for IoT
 apt install -y python3-pip
 python3.9 -m pip install setuptools --upgrade
-python3.9 -m pip install pymodbus==2.5.2 urllib3==1.26.6 setuptools termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
+python3.9 -m pip install pymodbus==2.5.2 urllib3==1.26.6 termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
 python3 -m pip install pymodbus termcolor twisted

--- a/installation.sh
+++ b/installation.sh
@@ -13,5 +13,4 @@ apt install -y default-jre
 #
 # Python3.5 will be used for emulated networks (modbus), Python3.9 will be used for IoT
 apt install -y python3-pip
-python3.9 -m pip install pymodbus==2.5.2 urllib3==1.26.6 termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
 python3 -m pip install pymodbus termcolor twisted

--- a/installation.sh
+++ b/installation.sh
@@ -13,5 +13,6 @@ apt install -y default-jre
 #
 # Python3.5 will be used for emulated networks (modbus), Python3.9 will be used for IoT
 apt install -y python3-pip
+python3.9 -m pip install setuptools --upgrade
 python3.9 -m pip install pymodbus==2.5.2 urllib3==1.26.6 setuptools termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
 python3 -m pip install pymodbus termcolor twisted

--- a/installation.sh
+++ b/installation.sh
@@ -13,5 +13,5 @@ apt install -y default-jre
 #
 # Python3.5 will be used for emulated networks (modbus), Python3.9 will be used for IoT
 apt install -y python3-pip
-python3.9 -m pip install pymodbus==2.5.2 termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
+python3.9 -m pip install pymodbus==2.5.2 urllib3==1.26.6 termcolor twisted flask requests cbor2 beebotte kpn_senml psutil pymongo numpy matplotlib mpremote
 python3 -m pip install pymodbus termcolor twisted


### PR DESCRIPTION
Two elements where blocking the use of the module beebotte.

The version of the setuptools in the the VM was too old, a line to upgrade it has been introduced.

Beebotte required an old version of urllib3, the version has been specified in the script.

This run on a new VM.